### PR TITLE
FIX: set_favorite_level expects int not str. Update old version string in XML header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # domoticz-AirPurifier
-Domoticz plugin for Xiaomi AirPurifier 2
+Domoticz plugin for Xiaomi AirPurifier 2/2S
 * Based on repository https://github.com/lrybak/domoticz-airly/
 * and script for Samsung TV: https://www.domoticz.com/wiki/Plugins/SamsungTV.html
 * and base on repository https://github.com/rytilahti/python-miio
@@ -18,7 +18,7 @@ cd YOUR_DOMOTICZ_PATH/plugins
 git clone https://github.com/kofec/domoticz-AirPurifier
 ```
 First use script "MyAir.py" to verify if you have needed python modules
-e.g: 
+e.g:
 ```
 ./MyAir.py 192.168.1.1 850000000000000000000000002 --debug
 ./MyAir.py -h
@@ -27,7 +27,7 @@ usage: MyAir.py [-h] [--mode {Auto,Favorite,Idle,Silent}]
                 [--debug]
                 IPaddress token
 
-Script which comunicate with AirPurfier 2.
+Script which comunicate with AirPurfier 2/2S.
 
 positional arguments:
   IPaddress             IP address of AirPurfier
@@ -41,6 +41,7 @@ optional arguments:
                         choose mode operation
   --power {ON,OFF}      power ON/OFF
   --debug               if define more output is printed
+  --led {ON,OFF}        turn led on/off
 ```
 * check where modules was installed and in file plugin.py find and correct below variable (in my case 2 instances) if needed
 pathOfPackages = '/usr/local/lib/python3.5/dist-packages'

--- a/plugin.py
+++ b/plugin.py
@@ -26,9 +26,12 @@
 #   - Expose Filter statistics to domoticz
 # v0.2.1
 #   - Expose illuminance to domoticz
+# v0.2.2
+#   - Update old version definition in xml
+#   - Fix set_favorite_level. python-miio library expects int not str.
 #
 """
-<plugin key="AirPurifier" name="AirPurifier" author="kofec" version="0.1.1" wikilink="https://github.com/rytilahti/python-miio" externallink="https://github.com/kofec/domoticz-AirPurifier">
+<plugin key="AirPurifier" name="AirPurifier" author="kofec" version="0.2.2" wikilink="https://github.com/rytilahti/python-miio" externallink="https://github.com/kofec/domoticz-AirPurifier">
     <params>
 		<param field="Address" label="IP Address" width="200px" required="true" default="127.0.0.1"/>
 		<param field="Mode1" label="AirPurifier Token" default="" width="400px" required="true"  />
@@ -145,7 +148,7 @@ class BasePlugin:
 
     def __init__(self):
         # Consts
-        self.version = "0.2.1"
+        self.version = "0.2.2"
 
         self.EXCEPTIONS = {
             "SENSOR_NOT_FOUND":     1,
@@ -387,7 +390,7 @@ class BasePlugin:
                 self.myAir.set_mode(miio.airpurifier.OperationMode.Auto)
                 UpdateDevice(self.UNIT_MODE_CONTROL, 30, '30')
             elif Unit == self.UNIT_MOTOR_SPEED_FAVORITE:
-                self.myAir.set_favorite_level(str(int(int(Level)/10)))
+                self.myAir.set_favorite_level(int(int(Level)/10))
             elif Unit == self.UNIT_LED:
                 enabled = str(Command).upper() == "ON"
                 self.myAir.set_led(enabled)


### PR DESCRIPTION
* Fix set_favorite_level. python-miio library expects int not str. when calling the function.
* Update old version definition in XML header